### PR TITLE
Clarifies PTO policy

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+markdown: kramdown


### PR DESCRIPTION
Specifies that PTO is calculated per calendar year, and that the  benefit for new hires is pro-rated based upon the number of working days remaining in the calendar year.
